### PR TITLE
added error message for empty board name

### DIFF
--- a/client/src/components/CreateBoardComponent.tsx
+++ b/client/src/components/CreateBoardComponent.tsx
@@ -18,6 +18,7 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
 	handleCancel,
 }) => {
 	const [newBoard, setNewBoard] = useState<Board>(emptyBoard);
+	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
 		setNewBoard((prevBoard) => ({
@@ -31,9 +32,25 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
 			...prevBoard,
 			name: e.target.value,
 		}));
+		setError(null); // Clear error when user starts typing
 	};
 
+	const handleSubmit = () => {
+    if (!newBoard.name.trim()) {
+      setError("Please name your board.");
+      return;
+    }
+
+    try {
+      handleAddNewBoard(newBoard);
+    } catch (err) {
+      setError("Failed to create board. Please try again later.");
+    }
+  };
+
 	return (
+		<div className="flex flex-col mb-4">
+
 		<div className="flex flex-row mb-4">
 			<input
 				className="p-2 border rounded mr-2 w-1/2"
@@ -41,15 +58,16 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
 				placeholder="Board Name"
 				value={newBoard.name}
 				onChange={handleChange}
+				maxLength={30}
 				onKeyDown={(e) => {
 					if (e.key === "Enter") {
-						handleAddNewBoard(newBoard);
+						handleSubmit();
 					}
 				}}
 			/>
 			<button
 				className="border rounded p-2 w-1/2 mr-2 bg-flair font-primary text-white px-4 py-2 hover:text-secondaryElements"
-				onClick={() => handleAddNewBoard(newBoard)}
+				onClick={() => handleSubmit()}
 			>
 				Create New Board
 			</button>
@@ -59,6 +77,8 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
       >
         Cancel
       </button>
+		</div>
+			{error && <p className="text-red-500 mt-2">{error}</p>}
 		</div>
 	);
 };

--- a/client/src/components/EditBoardName.tsx
+++ b/client/src/components/EditBoardName.tsx
@@ -53,11 +53,6 @@ const EditBoardName: React.FC<EditBoardNameProps> = ({ board, onSuccess }) => {
 			return;
 		}
 
-		if (newName.length > 30) {
-			setError("Board name must be 30 characters or less.");
-			return;
-		}
-
 		setIsLoading(true);
 		setError(null);
 


### PR DESCRIPTION
added error catch and message to name the board when creating. For issue #64 
![Screenshot 2024-06-25 095234](https://github.com/Alforoan/studyflow/assets/148730648/176bbea7-4ec5-4f31-8ece-45ef0c60d61b)
