### PR TITLE
fix bug with non unique name being added

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -152,6 +152,10 @@ const Home: React.FC = () => {
 	};
 
 	const handleAddNewBoard = async (newBoard: Board) => {
+		if (userBoards.some((board) => board.name === newBoard.name)) {
+      postNewBoard(newBoard);
+      return;
+    }
 		setIsAddingNewBoard(false);
 		newBoard.cards = [newCard];
 		postNewBoard(newBoard);


### PR DESCRIPTION
When a user tries to make a board with a name that already exists, it should give an error and not render what is normally rendered upon successful creation of the board.