### PR TITLE
fix bug of different user not being able to add the same name board

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -78,7 +78,8 @@ def create_board():
         name = data.get('name')
         uuid = data.get('uuid')
         user = User.query.filter_by(email=email).first()
-        name_exists = Board.query.filter_by(name=name).first()
+        print('user', user.email)
+        name_exists = Board.query.filter_by(user_id=user.id, name=name).first()
         user_id = user.id
         if name_exists:
             return jsonify({'error': 'Board name already exists'}), 400

--- a/server/models.py
+++ b/server/models.py
@@ -3,7 +3,7 @@ from app import db
 class Board(db.Model):
     __tablename__ = 'boards'
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String(80), unique=True, nullable=False)
+    name = db.Column(db.String(80), unique=False, nullable=False)
     uuid = db.Column(db.String(80), unique=True, nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
 


### PR DESCRIPTION
before: 
user 1: adds a board with a name of 'hi'
user 2: adds a board with a name of 'hi'

user 2 gets an error and cannot save the board name in the database

after:
user 2 can