### PR TITLE
render upload button only if have cards

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -187,7 +187,9 @@ const Home: React.FC = () => {
       {selectedBoard &&
         !selectedCard &&
         !isTemplate &&
-        !uploadedTemplateNames.includes(selectedBoard!.name) && (
+        !uploadedTemplateNames.includes(selectedBoard!.name) && 
+        selectedBoard.cards?.length &&
+        selectedBoard.cards.length > 1 && (
           <UploadBoardComponent />
         )}
       {!selectedBoard && !selectedCard && !isAddingNewBoard && (


### PR DESCRIPTION
rendered the Upload button only if the user has cards in their board. This was just a quick fix, let me know if prefer the other option listed in issue #147.
![Screenshot 2024-07-02 195033](https://github.com/Alforoan/studyflow/assets/148730648/bf93eb4e-89a3-462a-90a8-0d8be4fb6a52)
![Screenshot 2024-07-02 195024](https://github.com/Alforoan/studyflow/assets/148730648/c8904b62-3a38-4fbf-a385-56f45a734447)
 