### PR TITLE
fixed e2e tests errors due to existing board names

### DIFF
--- a/client/cypress/e2e/account-actions.cy.js
+++ b/client/cypress/e2e/account-actions.cy.js
@@ -5,7 +5,7 @@ describe("User checks out account page", () => {
     cy.login(); // Custom command for logging in
   });
   
-  it("Should be able to navigate to Account page and request a passowrd change and dark mode toggle", () => {
+  it("Should be able to navigate to Account page and request a passowrd change", () => {
     // Naviagte to Account page
     cy.contains("Account").click();
 
@@ -13,9 +13,7 @@ describe("User checks out account page", () => {
     cy.contains("Your Templates").should("exist");
     cy.contains("Account Actions").should("exist");
     cy.contains("Reset Password").should("exist");
-    cy.contains("Dark Mode").click();
-    cy.contains("Light Mode").click();
-   
+
     // Log out and assert redirection to Landing page
     cy.contains("Log out").click();
     cy.contains("Sign Up Here").should("exist");

--- a/client/cypress/e2e/board-crud.cy.js
+++ b/client/cypress/e2e/board-crud.cy.js
@@ -12,11 +12,8 @@ describe("User board CRUD operations", () => {
     cy.get('input[placeholder="Board Name"]').type("New Board Test");
     cy.contains("Create New Board").click();
 
-    // Wait for 3 seconds
-    cy.wait(3000);
-
     // Click the Home link
-    cy.contains("Home").click();
+    cy.contains("Home").click({ force: true });
 
     cy.contains("New Board Test").click();
     cy.contains("Edit").click();
@@ -28,11 +25,8 @@ describe("User board CRUD operations", () => {
     cy.contains("Save").click();
     cy.contains("New Board Test edited").click();
 
-    // Wait for 3 seconds
-    cy.wait(3000);
-
     // Click the Home link
-    cy.contains("Home").click();
+    cy.contains("Home").click({ force: true });
 
     // Delete the created board created
     cy.contains("New Board Test edited").parent()
@@ -47,7 +41,7 @@ describe("User board CRUD operations", () => {
     cy.wait(3000);
 
     // Log out and assert redirection to Landing page
-    cy.contains("Log out").click();
+    cy.contains("Log out").click({ force: true });
     cy.contains("Sign Up Here").should("exist");
   });
 });

--- a/client/cypress/e2e/card-crud.cy.js
+++ b/client/cypress/e2e/card-crud.cy.js
@@ -43,8 +43,19 @@ describe("User card CRUD operations", () => {
     // Wait for 5 seconds
     cy.wait(5000);
 
+    cy.contains("Home").click({ force: true });
+
+    // Delete the downloaded template
+    cy.contains("New board w/ card").parent()
+      .find('svg[aria-label="Delete board"]').click();
+
+    cy.contains('button', 'Delete').click();
+
+    // Verify the template is deleted
+    cy.contains("New board w/ card").should("not.exist");
+
     // Log out and assert redirection to Landing page
-    cy.contains("Log out").click();
+    cy.contains("Log out").click({ force: true });
     cy.contains("Sign Up Here").should("exist");
   });
 });

--- a/client/cypress/e2e/template-actions.cy.js
+++ b/client/cypress/e2e/template-actions.cy.js
@@ -1,5 +1,5 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-describe("User board CRUD operations", () => {
+describe("User template CRUD operations", () => {
   before(() => {
     // login once before any tests in this describe block
     cy.login(); // Custom command for logging in
@@ -29,18 +29,36 @@ describe("User board CRUD operations", () => {
     // Wait for 5 seconds
     cy.wait(5000);
 
-    cy.contains("Home").click();
+    cy.contains("Home").click({ force: true });
 
     cy.contains("Search Templates").click();
     cy.contains("Sorting Algorithms").click();
     cy.contains("Download Template").click();
-    cy.contains("Home").click();
+    cy.contains("Home").click({ force: true });
     cy.contains("Sorting Algorithms").should("exist");
+
+    // Delete the downloaded template
+    cy.contains("Sorting Algorithms").parent()
+      .find('svg[aria-label="Delete board"]').click();
+
+    cy.contains('button', 'Delete').click();
+
+    // Verify the template is deleted
+    cy.contains("Sorting Algorithms").should("not.exist");
+
+    // Delete the created board
+    cy.contains("New Board Test").parent()
+      .find('svg[aria-label="Delete board"]').click();
+
+    cy.contains('button', 'Delete').click();
+
+    // Verify the template is deleted
+    cy.contains("New Board Test").should("not.exist");
 
     cy.get(".Toastify__toast-container")
       .should("be.visible")
       .then(() => {
-        cy.get(".Toastify__toast-container .Toastify__close-button").click();
+        cy.get(".Toastify__toast-container .Toastify__close-button").click({multiple: true});
       });
 
     // Log out and assert redirection to Landing page


### PR DESCRIPTION
Adjusted the e2e tests so that any boards created during testing are also deleted in the same test. This was creating errors with future tests, "board name already exists".