### PR TITLE
fixed navbar overflow and cards centering on the landing page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,8 @@ function App() {
   const { isAuthenticated, isLoading } = useAuth0();
   const { isAdmin } = useAuth();
 
+  const bgColor = useColorModeValue("white", "#313338");
+
   if (isLoading) {
     return <Loading isLoading={isLoading} />;
   }
@@ -35,7 +37,7 @@ function App() {
         <Box
           minH="100vh"
           fontFamily="Roboto, Helvetica, sans-serif"
-          bg={useColorModeValue("white", "#313338")}
+          bg={bgColor}
           className="transition-all duration-500 ease-in-out"
         >
           <Navbar />

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -365,6 +365,7 @@ const Navbar: React.FC = () => {
                   colorScheme={"blue"}
                   size={"md"}
                   onClick={() => loginWithRedirect()}
+                  display={{ base: "none", md: "inline-flex" }}
                 >
                   Sign Up
                 </Button>

--- a/client/src/components/StackedCards.tsx
+++ b/client/src/components/StackedCards.tsx
@@ -3,9 +3,11 @@ import React from "react";
 
 const StackedCards: React.FC = () => {
   return (
-    <div className="relative flex justify-center items-center text-primaryText">
+    <div className="relative flex justify-center items-center text-primaryText pb-8">
       <div className="relative">
-        <div className="absolute z-0 transform rotate-1 bg-gray-100 p-4 w-80 shadow-md rounded-lg top-8 -left-12">
+        <div className="absolute z-0 transform p-4 lg:w-80 shadow-md rounded-lg top-12 -left-8 lg:-left-20 lg:top-32 md:w-80"
+        style={{ backgroundColor: "#FEFCBF" }}
+        >
           <h2 className="text-lg font-bold mb-2">Quick Sort</h2>
           <ul className="list-disc list-inside">
             <li>YouTube Resource</li>
@@ -14,9 +16,11 @@ const StackedCards: React.FC = () => {
           </ul>
           <p className="mt-4">Notes: Google Doc Notes Link</p>
           <p className="mt-1">Time Estimate: 90 Minutes</p>
-          <p className="mt-1">Column: Not Started</p>
+          <p className="mt-1">Column: Backlog</p>
         </div>
-        <div className="relative z-10 bg-gray-100 p-4 w-80 shadow-md rounded-lg">
+        <div className="relative z-10 p-4 lg:w-80 md:w-80 shadow-md rounded-lg -right-8 lg:-right-20 lg:-top-20"
+        style={{ backgroundColor: "#bee3f8" }}
+        >
           <h2 className="text-lg font-bold mb-2">Merge Sort</h2>
           <ul className="list-disc list-inside">
             <li>YouTube Resource</li>

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -122,7 +122,7 @@ const Landing: React.FC = () => {
         </Stack>
 
         {/* Features and Stacked Cards on larger screens */}
-        <Grid templateColumns={{ base: "1fr", lg: "1fr 1fr" }} gap={8} mt={40}>
+        <Grid templateColumns={{ base: "1fr", lg: "1fr 1fr" }} gap={8} mt={{ base: 20, md: 32, lg: 40 }}>
           {/* Feature descriptions */}
           <GridItem>
             <Stack spacing={8}>
@@ -153,7 +153,7 @@ const Landing: React.FC = () => {
           </GridItem>
 
           {/* Stacked Cards Component */}
-          <GridItem>
+          <GridItem mt={{ base: 6 }}>
             <StackedCards />
           </GridItem>
         </Grid>


### PR DESCRIPTION
I know we are going to change the Landing page eventually. I noticed an overflow issue on some of the mobile sizes. I hid the Sign Up button in the navbar on smaller screens since there is a Sign Up Here button in the page. Also in the mobile view the stacked cards were not centered, so I adjusted those. If you guys think it is OK for now I was mainly just making a quick fix incase someone looks up the site on our resumes and stuff. I also fixed the minor issue in the console in issue #241.
![Screenshot 2024-08-25 112814](https://github.com/user-attachments/assets/7f9ebbb1-0097-494f-b857-c2459c3bb46f)
![Screenshot 2024-08-25 120437](https://github.com/user-attachments/assets/93f825a0-d946-427c-95b9-dc62c44053c4)
