### PR TITLE
added coming soon tooltip to social icons

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Tooltip,
   Box,
   IconButton,
   useColorModeValue,
@@ -32,35 +33,41 @@ const Footer: React.FC = () => {
         </Box>
         <Box>
           <Stack direction="row" spacing={6}>
-            <IconButton
-              as="a"
-              href="https://facebook.com/yourhandle"
-              aria-label="Facebook"
-              icon={<FaFacebook />}
-              variant="link"
-              size="lg"
-              _hover={{
-                color: useColorModeValue("facebook.600", "facebook.400"),
-              }}
-            />
-            <IconButton
-              as="a"
-              href="https://twitter.com/yourhandle"
-              aria-label="Twitter"
-              icon={<FaTwitter />}
-              variant="link"
-              size="lg"
-              _hover={{ color: useColorModeValue("blue.600", "blue.400") }}
-            />
-            <IconButton
-              as="a"
-              href="https://instagram.com/yourhandle"
-              aria-label="Instagram"
-              icon={<FaInstagram />}
-              variant="link"
-              size="lg"
-              _hover={{ color: useColorModeValue("#C13584", "#C13584") }}
-            />
+            <Tooltip label="Coming Soon" aria-label="Facebook Coming Soon">
+              <IconButton
+                as="a"
+                // href="https://facebook.com"
+                aria-label="Facebook"
+                icon={<FaFacebook />}
+                variant="link"
+                size="lg"
+                _hover={{
+                  color: useColorModeValue("facebook.600", "facebook.400"),
+                }}
+              />
+            </Tooltip>
+            <Tooltip label="Coming Soon" aria-label="Twitter Coming Soon">
+              <IconButton
+                as="a"
+                // href="https://twitter.com"
+                aria-label="Twitter"
+                icon={<FaTwitter />}
+                variant="link"
+                size="lg"
+                _hover={{ color: useColorModeValue("blue.600", "blue.400") }}
+              />
+            </Tooltip>
+            <Tooltip label="Coming Soon" aria-label="Instagram Coming Soon">
+              <IconButton
+                as="a"
+                // href="https://instagram.com/"
+                aria-label="Instagram"
+                icon={<FaInstagram />}
+                variant="link"
+                size="lg"
+                _hover={{ color: useColorModeValue("#C13584", "#C13584") }}
+              />
+            </Tooltip>
           </Stack>
         </Box>
       </Flex>


### PR DESCRIPTION
removed links for the social icons until we can set up something, or we may remove all together and add GitHub social icon. There is another company in the EU with the same name. So for now just have tooltips that say coming soon. or we can remove altogether. The tooltip is from ChakraUI.
![Screenshot 2024-08-30 100739](https://github.com/user-attachments/assets/fda9163d-17b4-4a0d-b027-f2eff96bb835)
