### PR TITLE
added tooltips to icons with no labels

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ import {
   Stack,
   // Image,
   useColorMode,
+  Tooltip,
 } from "@chakra-ui/react";
 import {
   AddIcon,
@@ -47,6 +48,8 @@ const Navbar: React.FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { resetState } = useStateReset();
+
+  const tooltipLabel = colorMode === "light" ? "Dark Mode" : "Light Mode";
 
   return (
     <>
@@ -92,37 +95,43 @@ const Navbar: React.FC = () => {
               </Box>
             </Link>
           </Flex>
-
           <Flex alignItems={"center"}>
             {isAuthenticated ? (
               <>
-                <Button
-                  variant={"solid"}
-                  bg="orange.500"
-                  _hover={{ "bg": "orange.600" }}
-                  color="white"
-                  size={"sm"}
-                  mr={{ base: "2", md: "4" }}
-                  as={Link}
-                  to={"/"}
-                  onClick={() => resetState()}
-                  aria-label="home icon"
+                <Tooltip label="Home" aria-label="home icon button">
+                  <Button
+                    variant={"solid"}
+                    bg="orange.500"
+                    _hover={{ bg: "orange.600" }}
+                    color="white"
+                    size={"sm"}
+                    mr={{ base: "2", md: "4" }}
+                    as={Link}
+                    to={"/"}
+                    onClick={() => resetState()}
+                    aria-label="home icon"
+                  >
+                    <IoHome />
+                  </Button>
+                </Tooltip>
+                <Tooltip
+                  label="Magic Wand - Creates a study plan for you"
+                  aria-label="magic wand icon  button"
                 >
-                  <IoHome />
-                </Button>
-                <Button
-                  variant={"solid"}
-                  bg="pink.500"
-                  _hover={{ "bg": "pink.600" }}
-                  color="white"
-                  size={"sm"}
-                  mr={{ base: "2", md: "4" }}
-                  as={Link}
-                  to={"/generate"}
-                  onClick={() => resetState()}
-                >
-                  <FaWandMagicSparkles />
-                </Button>
+                  <Button
+                    variant={"solid"}
+                    bg="pink.500"
+                    _hover={{ bg: "pink.600" }}
+                    color="white"
+                    size={"sm"}
+                    mr={{ base: "2", md: "4" }}
+                    as={Link}
+                    to={"/generate"}
+                    onClick={() => resetState()}
+                  >
+                    <FaWandMagicSparkles />
+                  </Button>
+                </Tooltip>
                 <Flex display={{ base: "none", md: "flex" }}>
                   <Button
                     variant={"solid"}
@@ -149,24 +158,34 @@ const Navbar: React.FC = () => {
                     Create New Board
                   </Button>
                 </Flex>
-                <Button onClick={toggleColorMode} mr={2}>
-                  {colorMode === "light" ? (
-                    <Brightness4Icon />
-                  ) : (
-                    <Brightness7Icon />
-                  )}
-                </Button>
+                <Tooltip
+                  label={tooltipLabel}
+                  aria-label="light-dark mode toggle button"
+                >
+                  <Button onClick={toggleColorMode} mr={2}>
+                    {colorMode === "light" ? (
+                      <Brightness4Icon />
+                    ) : (
+                      <Brightness7Icon />
+                    )}
+                  </Button>
+                </Tooltip>
                 <Menu>
-                  <MenuButton
-                    as={Button}
-                    rounded={"full"}
-                    variant={"link"}
-                    cursor={"pointer"}
-                    minW={0}
-                    aria-label="user icon"
+                  <Tooltip
+                    label={`Account: ${user?.name}`}
+                    aria-label="account-menu icon button"
                   >
-                    <Avatar size={"sm"} src={user?.picture} />
-                  </MenuButton>
+                    <MenuButton
+                      as={Button}
+                      rounded={"full"}
+                      variant={"link"}
+                      cursor={"pointer"}
+                      minW={0}
+                      aria-label="user icon"
+                    >
+                      <Avatar size={"sm"} src={user?.picture} />
+                    </MenuButton>
+                  </Tooltip>
                   <MenuList>
                     <MenuItem
                       as={Link}
@@ -222,13 +241,18 @@ const Navbar: React.FC = () => {
                 >
                   Sign Up
                 </Button>
-                <Button onClick={toggleColorMode} mr={2}>
-                  {colorMode === "light" ? (
-                    <Brightness4Icon />
-                  ) : (
-                    <Brightness7Icon />
-                  )}
-                </Button>
+                <Tooltip
+                  label={tooltipLabel}
+                  aria-label="light-dark mode toggle button"
+                >
+                  <Button onClick={toggleColorMode} mr={2}>
+                    {colorMode === "light" ? (
+                      <Brightness4Icon />
+                    ) : (
+                      <Brightness7Icon />
+                    )}
+                  </Button>
+                </Tooltip>
               </Stack>
             )}
           </Flex>


### PR DESCRIPTION

![Screenshot 2024-09-04 092658](https://github.com/user-attachments/assets/42725a80-f8e8-49dd-9f16-6868c5ff6f9c)

Added tooltips to the navbar icon/buttons with no labels. The home, magic wand, light/dark toggle, and the account menu image. I did try and see what they looked like having them added to the 2 large main buttons in the navbar, for find a template the tooltip said - see what others are studying (or similar) and the create a new board - tooltip said (create your own study plan)
I think that was too much though. If we can come up with 3 concise sentences or so fo the landing or when you log in and there is no boards, that specify: These are the 3 features that I feel need to be conveyed, with magic wand the most. The other 2 can be figured out. 

1) You can use magic wand to create a complete study plan for you. (magic wand)
2) You can use a study plan that someone else has used. (templates)
3) If you already know what you want to study you can create your own study plan. (create new board)

Maybe even just a simple sentence after logging in, if the user has no boards: "It looks like you don't have any study plans yet, try the "Magic Wand" above to get started. The tooltip label can be shortened. We just need a way to convey that's what it does. Or just have it say "Magic Wand" and users are curious and click on it?
