### PR TITLE
fixed AI backend stuff & a few frontend issues

### DIFF
--- a/client/src/components/BoardComponent.tsx
+++ b/client/src/components/BoardComponent.tsx
@@ -147,75 +147,74 @@ const BoardComponent: React.FC = () => {
     return arr;
   };
 
-  if (!selectedBoard) {
-    return (
-      <>
-        {noTitleWarning && (
-          <Text color="red.400" mb={4}>
-            You must add a board title first!
-          </Text>
-        )}
-        <Box w="100%" overflowX={{ base: "auto", md: "hidden" }}>
-          <Flex
-            flexGrow={1}
-            gap={4}
-            w="full"
-            minW={{ base: "900px", md: "100%" }}
-            overflowX="auto"
-          >
-            {columns.map((col) => (
-              <Box
-                w={{ base: "300px", md: "100%" }}
-                p={2}
-                bg="gray.100"
-                borderRadius="md"
-                key={col.key}
-                aria-label={`${col.title} column`}
-              >
-                <Heading
-                  size="md"
-                  fontWeight="bold"
-                  mb={2}
-                  aria-label={`${col.title} column title`}
-                  color="blackAlpha.900"
-                  fontSize="md"
-                  py={2}
-                  px={4}
-                >
-                  {col.title}
-                </Heading>
-                <Flex direction="column" flexGrow={1}>
-                  {col.title === "Backlog" && (
-                    <Box
-                      aria-label={"Create Card"}
-                      bg="gray.100"
-                      py={2}
-                      px={4}
-                      _hover={{ bg: "gray.200" }}
-                      cursor="pointer"
-                      rounded="md"
-                      onClick={() => setNoTitleWarning(true)}
-                    >
-                      <Heading
-                        fontSize="md"
-                        mb={0}
-                        fontWeight="500"
-                        alignItems={"center"}
-                        color="gray.600"
-                      >
-                        <SmallAddIcon mr={2} />
-                        Create New Card
-                      </Heading>
-                    </Box>
-                  )}
-                </Flex>
-              </Box>
-            ))}
-          </Flex>
-        </Box>
-      </>
-    );
-  }
+  if (!selectedBoard) return;
+  // return (
+  //   <>
+  //     {noTitleWarning && (
+  //       <Text color="red.400" mb={4}>
+  //         You must add a board title first!
+  //       </Text>
+  //     )}
+  //     <Box w="100%" overflowX={{ base: "auto", md: "hidden" }}>
+  //       <Flex
+  //         flexGrow={1}
+  //         gap={4}
+  //         w="full"
+  //         minW={{ base: "900px", md: "100%" }}
+  //         overflowX="auto"
+  //       >
+  //         {columns.map((col) => (
+  //           <Box
+  //             w={{ base: "300px", md: "100%" }}
+  //             p={2}
+  //             bg="gray.100"
+  //             borderRadius="md"
+  //             key={col.key}
+  //             aria-label={`${col.title} column`}
+  //           >
+  //             <Heading
+  //               size="md"
+  //               fontWeight="bold"
+  //               mb={2}
+  //               aria-label={`${col.title} column title`}
+  //               color="blackAlpha.900"
+  //               fontSize="md"
+  //               py={2}
+  //               px={4}
+  //             >
+  //               {col.title}
+  //             </Heading>
+  //             <Flex direction="column" flexGrow={1}>
+  //               {col.title === "Backlog" && (
+  //                 <Box
+  //                   aria-label={"Create Card"}
+  //                   bg="gray.100"
+  //                   py={2}
+  //                   px={4}
+  //                   _hover={{ bg: "gray.200" }}
+  //                   cursor="pointer"
+  //                   rounded="md"
+  //                   onClick={() => setNoTitleWarning(true)}
+  //                 >
+  //                   <Heading
+  //                     fontSize="md"
+  //                     mb={0}
+  //                     fontWeight="500"
+  //                     alignItems={"center"}
+  //                     color="gray.600"
+  //                   >
+  //                     <SmallAddIcon mr={2} />
+  //                     Create New Card
+  //                   </Heading>
+  //                 </Box>
+  //               )}
+  //             </Flex>
+  //           </Box>
+  //         ))}
+  //       </Flex>
+  //     </Box>
+  //   </>
+  // );
 
   return (
     <Flex direction="column">
@@ -333,7 +332,12 @@ const BoardComponent: React.FC = () => {
               </Flex>
             </Box>
           ) : (
-            <Box w="100%" overflowX={{ base: "auto", md: "hidden" }} mb="4" color="blackAlpha.900">
+            <Box
+              w="100%"
+              overflowX={{ base: "auto", md: "hidden" }}
+              mb="4"
+              color="blackAlpha.900"
+            >
               <Flex
                 flexGrow={1}
                 gap={4}

--- a/client/src/components/CreateBoardComponent.tsx
+++ b/client/src/components/CreateBoardComponent.tsx
@@ -4,10 +4,11 @@ import { v4 as uuidv4 } from "uuid";
 import { useBoard } from "../context/BoardContext";
 import ErrorMessage from "./ErrorMessage";
 import { validateTextInput } from "../utils/inputUtils";
-import { Flex, Input, Button } from "@chakra-ui/react";
-import { AddIcon, CloseIcon } from "@chakra-ui/icons";
+import { Flex, Input, Button, Text, Box } from "@chakra-ui/react";
+import { AddIcon, CheckIcon, CloseIcon } from "@chakra-ui/icons";
 import { useBreakpointValue } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
+import { FaWandMagicSparkles } from "react-icons/fa6";
 
 interface CreateBoardComponentProps {
   handleCancel: () => void;
@@ -41,6 +42,10 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
       name: e.target.value,
     }));
     setError(null); // Clear error when user starts typing
+  };
+
+  const handleGenerate = () => {
+    navigate("/generate");
   };
 
   const handleSubmit = () => {
@@ -80,12 +85,37 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
 
   const createBoardIcon = useBreakpointValue({
     base: undefined,
-    md: <AddIcon />,
+    md: <CheckIcon />,
   });
   const cancelIcon = useBreakpointValue({ base: undefined, md: <CloseIcon /> });
-
+  const generateIcon = useBreakpointValue({
+    base: undefined,
+    md: <FaWandMagicSparkles />,
+  });
   return (
     <Flex direction="column" mb={4}>
+      <Button
+        w="100%"
+        mr={2}
+        bg="pink.500"
+        color="white"
+        px={2}
+        py={2}
+        _hover={{ bg: "pink.700" }}
+        leftIcon={generateIcon}
+        onClick={() => handleGenerate()}
+        aria-label="Generate With AI Button"
+        alignSelf={"center"}
+      >
+        Generate AI Board
+      </Button>
+      <Flex direction="row" alignItems="center" justifyContent="center" my={8}>
+        <Box flex={1} height="1px" bg="gray.400" />
+        <Text textAlign="center" fontSize="md" fontWeight="normal" mx={8}>
+          Or Start From Scratch
+        </Text>
+        <Box flex={1} height="1px" bg="gray.400" />
+      </Flex>
       <Flex direction="row" mb={4}>
         <Input
           p={2}
@@ -115,16 +145,19 @@ const CreateBoardComponent: React.FC<CreateBoardComponentProps> = ({
           leftIcon={createBoardIcon}
           onClick={() => handleSubmit()}
           aria-label="Create New Board Button"
+          _hover={{ bg: "teal.700" }}
         >
-          {createBoardIcon ? "Create Board" : <AddIcon />}
+          {createBoardIcon ? "Create Board" : <CheckIcon />}
         </Button>
+
         <Button
-          w="12%"
+          w="10%"
           bg="red.400"
           color="white"
           leftIcon={cancelIcon}
           onClick={handleCancel}
           aria-label="Cancel Button"
+          _hover={{ bg: "red.600" }}
         >
           {cancelIcon ? "Cancel" : <CloseIcon />}
         </Button>

--- a/client/src/components/DownloadTemplateComponent.tsx
+++ b/client/src/components/DownloadTemplateComponent.tsx
@@ -56,7 +56,7 @@ const DownloadTemplateComponent = () => {
         leftIcon={<DownloadIcon />}
         _hover={{ bg: "gray.600" }}
       >
-        Download Template
+        Save Template
       </Button>
     </Flex>
   );

--- a/client/src/components/UploadBoardComponent.tsx
+++ b/client/src/components/UploadBoardComponent.tsx
@@ -67,9 +67,9 @@ const UploadBoardComponent: React.FC<UploadProps> = ({ isEditingTitle }) => {
       justifyContent={{ base: "center", md: "left" }}
       leftIcon={<Icon as={DownloadIcon} transform="rotate(180deg)" />}
       _hover={{ bg: "gray.600" }}
-      aria-label="Upload Template Button" 
+      aria-label="Upload Template Button"
     >
-      Upload Template
+      Make Board Public
     </Button>
   );
 };

--- a/server/app.py
+++ b/server/app.py
@@ -529,12 +529,14 @@ def create_subtopics():
 
         print(f"Text: {text}, Num Subtopics: {num_subtopics}, Existing Subtopics: {existing_subtopics}")
 
+        complexity = "comprehensive analysis" if num_subtopics == "a lot" else "solid understanding" if num_subtopics == "some" else "brief overview"
+
         if existing_subtopics:
             existing_subtopics_str = ", ".join(
                 [f'"{subtopic}"' for subtopic in existing_subtopics]
             )
             prompt = f"""You already have the following subtopic titles: [{existing_subtopics_str}]. 
-            Please build on these by adding {num_subtopics} new distinct subtopics related to '{text}'.
+            Please build on these by adding exactly 3 new distinct subtopics related to '{text}'.
             The goal for these subtopics is to provide a comprehensive overview of the main topic. 
             Each new subtopic should include a name and a short summary. 
             The subtopic name should be a few words long and be specific to the context of what the topic is about. Avoid generic names.
@@ -547,7 +549,7 @@ def create_subtopics():
             Instead, rephrase the text to exclude these characters."""
         else:
 
-            prompt = f"""Please break down the topic '{text}' into exactly {num_subtopics} distinct subtopics. 
+            prompt = f"""Please break down the topic '{text}' into '{num_subtopics}' distinct subtopics in order to give a '{complexity}' of the topic. 
             Each subtopic should include a name and a short summary. 
             The subtopic name should be a few words long and be specific to the context of what the topic is about. Avoid generic names.
             The goal for these subtopics is to provide a comprehensive overview of the main topic. 
@@ -802,7 +804,12 @@ def get_youtube_tutorial(topic):
 
     if result['result']:
         video = result['result'][0]
-        duration = int(video['duration'].split(':')[0])
+        duration_parts = video['duration'].split(':')
+        if len(duration_parts) == 3:
+            duration = int(duration_parts[0]) * 60 + int(duration_parts[1])
+        else:
+            duration = int(duration_parts[0])
+
         return {
             'topic': topic,
             'video_url': video['link'],


### PR DESCRIPTION
**Backend**
Update link queries to make sure they have context from overall board topic + subtopic + detail when querying bing/yt 
Fix CORS issue
Give chatGPT a range of number of # of topics(3-6, 6-9, 9-12) to create instead of specific number (4,8,12) based on how in depth user chose

**Frontend**
For the generate page.. Fix implementation to not reset if all subtopics deleted
Add magic wand button on create board page
Update the wording for upload template and download board (makes it sound like it’s downloading to computer)