### PR TITLE
fix a bug regarding clicking on go back button not persisting data

### DIFF
--- a/client/src/components/TitleComponent.tsx
+++ b/client/src/components/TitleComponent.tsx
@@ -44,11 +44,8 @@ const TitleComponent = () => {
         setIsSearching(true);
       } else {
         const cards = await getCards(selectedBoard.uuid, false);
-        console.log('selected board from go back',selectedBoard);
         
         setSelectedBoard((prevBoard) => {
-          console.log({prevBoard});
-          
           const updatedBoard = prevBoard
             ? { ...prevBoard }
             : { ...selectedBoard };

--- a/client/src/components/TitleComponent.tsx
+++ b/client/src/components/TitleComponent.tsx
@@ -8,6 +8,7 @@ import { ArrowBackIcon } from "@chakra-ui/icons";
 import DownloadTemplateComponent from "./DownloadTemplateComponent";
 import UploadBoardComponent from "./UploadBoardComponent";
 import { useEffect, useState } from "react";
+import { useGetCards } from '../hooks/useAPI';
 
 const TitleComponent = () => {
   const {
@@ -22,14 +23,15 @@ const TitleComponent = () => {
   } = useBoard();
 
   const navigate = useNavigate();
+  const { getCards } = useGetCards();
 
   const { isTemplate, setIsTemplate, templateIsOwned, uploadedTemplateNames } =
     useTemplates();
 
-  const handleGoBack = () => {
+  const handleGoBack = async() => {
     if (!selectedCard && !selectedBoard && isSearching) {
       setIsSearching(false);
-      navigate("/");
+      navigate("/home");
       return;
     }
 
@@ -41,6 +43,21 @@ const TitleComponent = () => {
         setIsTemplate(false);
         setIsSearching(true);
       } else {
+        const cards = await getCards(selectedBoard.uuid, false);
+        console.log('selected board from go back',selectedBoard);
+        
+        setSelectedBoard((prevBoard) => {
+          console.log({prevBoard});
+          
+          const updatedBoard = prevBoard
+            ? { ...prevBoard }
+            : { ...selectedBoard };
+
+          return {
+            ...updatedBoard, 
+            cards: cards, 
+          };
+        });
         navigate("/");
       }
     }


### PR DESCRIPTION
Do not refresh when testing below.

Old:
1. click on any board
2. click on any card
3. check an item
4. close out of the card details
5. go back
6. click on the same board and the item you checked will remain unchecked until you refresh 

new:
1-5: same
6: click on the same board except this time the checked items stay checked.